### PR TITLE
fix: :ambulance: use png in readme instead of svg

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-![Logo](res/icon.svg)
+<img alt="Logo" src="res/icon.png" width="280">
 
 # VS Code Links
 


### PR DESCRIPTION
Because `@vscode/vsce` doesn't accept svg in readme